### PR TITLE
use the same classloader which loaded the jnagmp jar to find the embe…

### DIFF
--- a/jnagmp/src/main/java/com/squareup/jnagmp/LibGmp.java
+++ b/jnagmp/src/main/java/com/squareup/jnagmp/LibGmp.java
@@ -26,7 +26,6 @@ import com.sun.jna.Native;
 import com.sun.jna.NativeLibrary;
 import com.sun.jna.NativeLong;
 import com.sun.jna.Pointer;
-import java.io.File;
 
 /** Direct JNA mappings to select libgmp functions. */
 public final class LibGmp {
@@ -53,20 +52,7 @@ public final class LibGmp {
   }
 
   private static void loadLibGmp() {
-    try {
-      // Explicitly try to load the embedded version first.
-      File file = Native.extractFromResourcePath("gmp", LibGmp.class.getClassLoader());
-      load(file.getAbsolutePath());
-      return;
-    } catch (Exception ignored) {
-    } catch (UnsatisfiedLinkError ignored) {
-    }
-    // Fall back to system-wide search.
-    load("gmp");
-  }
-
-  private static void load(String name) {
-    NativeLibrary library = NativeLibrary.getInstance(name, LibGmp.class.getClassLoader());
+    NativeLibrary library = NativeLibrary.getInstance("gmp", LibGmp.class.getClassLoader());
     Native.register(LibGmp.class, library);
     Native.register(SIZE_T_CLASS, library);
   }

--- a/jnagmp/src/main/java/com/squareup/jnagmp/LibGmp.java
+++ b/jnagmp/src/main/java/com/squareup/jnagmp/LibGmp.java
@@ -55,7 +55,7 @@ public final class LibGmp {
   private static void loadLibGmp() {
     try {
       // Explicitly try to load the embedded version first.
-      File file = Native.extractFromResourcePath("gmp");
+      File file = Native.extractFromResourcePath("gmp", LibGmp.class.getClassLoader());
       load(file.getAbsolutePath());
       return;
     } catch (Exception ignored) {
@@ -66,7 +66,7 @@ public final class LibGmp {
   }
 
   private static void load(String name) {
-    NativeLibrary library = NativeLibrary.getInstance(name);
+    NativeLibrary library = NativeLibrary.getInstance(name, LibGmp.class.getClassLoader());
     Native.register(LibGmp.class, library);
     Native.register(SIZE_T_CLASS, library);
   }


### PR DESCRIPTION
…dded native library

this allows this library to be used with OSGi or within JRuby as jar loaded by the
JRuby runtime. currently the workaround is to set the Thread.contextClassLoader with the
right classloader, load LibGmp.class and reset the context classloader.

Sponsored by Lookout Inc.