### PR TITLE
modInverse support

### DIFF
--- a/jnagmp/src/main/java/com/squareup/jnagmp/Gmp.java
+++ b/jnagmp/src/main/java/com/squareup/jnagmp/Gmp.java
@@ -25,6 +25,7 @@ import static com.squareup.jnagmp.LibGmp.__gmpz_clear;
 import static com.squareup.jnagmp.LibGmp.__gmpz_export;
 import static com.squareup.jnagmp.LibGmp.__gmpz_import;
 import static com.squareup.jnagmp.LibGmp.__gmpz_init;
+import static com.squareup.jnagmp.LibGmp.__gmpz_invert;
 import static com.squareup.jnagmp.LibGmp.__gmpz_powm;
 import static com.squareup.jnagmp.LibGmp.__gmpz_powm_sec;
 import static com.squareup.jnagmp.LibGmp.readSizeT;
@@ -123,6 +124,21 @@ public final class Gmp {
     }
     return INSTANCE.get().modPowSecureImpl(base, exponent, modulus);
   }
+  
+  /**
+   * Calculate val^-1 % modulus.
+   *
+   * @param val must be positive
+   * @param modulus the modulus
+   * @return val^-1 % modulus
+   * @throws ArithmeticException if modulus is non-positive or val is not invertible
+   */
+  public static BigInteger modInverse(BigInteger val, BigInteger modulus) {
+    if (modulus.signum() != 1) {
+      throw new ArithmeticException("modulus must be not zero and positive");
+    }  
+    return INSTANCE.get().modInverseImpl(val, modulus);
+  }
 
   /**
    * VISIBLE FOR TESTING. Reuse the same buffers over and over to minimize allocations and native
@@ -202,6 +218,20 @@ public final class Gmp {
     // The result size should be <= modulus size, but round up to the nearest byte.
     int requiredSize = (mod.bitLength() + 7) / 8;
     return new BigInteger(1, mpzExport(sharedOperands[3], requiredSize));
+  }
+  
+  private BigInteger modInverseImpl(BigInteger val, BigInteger mod) {
+    mpz_t valPeer = getPeer(val, sharedOperands[0]);
+    mpz_t modPeer = getPeer(mod, sharedOperands[1]);
+    
+    int res = __gmpz_invert(sharedOperands[2], valPeer, modPeer);
+    if (res == 0) {
+      throw new ArithmeticException("BigInteger not ivertible");
+    }
+    
+ // The result size should be <= modulus size, but round up to the nearest byte.
+    int requiredSize = (mod.bitLength() + 7) / 8;
+    return new BigInteger(1, mpzExport(sharedOperands[2], requiredSize));
   }
 
   /**

--- a/jnagmp/src/main/java/com/squareup/jnagmp/Gmp.java
+++ b/jnagmp/src/main/java/com/squareup/jnagmp/Gmp.java
@@ -124,7 +124,7 @@ public final class Gmp {
     }
     return INSTANCE.get().modPowSecureImpl(base, exponent, modulus);
   }
-  
+
   /**
    * Calculate val^-1 % modulus.
    *
@@ -136,7 +136,7 @@ public final class Gmp {
   public static BigInteger modInverse(BigInteger val, BigInteger modulus) {
     if (modulus.signum() != 1) {
       throw new ArithmeticException("modulus must be not zero and positive");
-    }  
+    }
     return INSTANCE.get().modInverseImpl(val, modulus);
   }
 
@@ -219,16 +219,16 @@ public final class Gmp {
     int requiredSize = (mod.bitLength() + 7) / 8;
     return new BigInteger(1, mpzExport(sharedOperands[3], requiredSize));
   }
-  
+
   private BigInteger modInverseImpl(BigInteger val, BigInteger mod) {
     mpz_t valPeer = getPeer(val, sharedOperands[0]);
     mpz_t modPeer = getPeer(mod, sharedOperands[1]);
-    
+
     int res = __gmpz_invert(sharedOperands[2], valPeer, modPeer);
     if (res == 0) {
       throw new ArithmeticException("BigInteger not ivertible");
     }
-    
+
  // The result size should be <= modulus size, but round up to the nearest byte.
     int requiredSize = (mod.bitLength() + 7) / 8;
     return new BigInteger(1, mpzExport(sharedOperands[2], requiredSize));

--- a/jnagmp/src/main/java/com/squareup/jnagmp/LibGmp.java
+++ b/jnagmp/src/main/java/com/squareup/jnagmp/LibGmp.java
@@ -314,6 +314,15 @@ public final class LibGmp {
    */
   public static native void __gmpz_powm_sec(mpz_t rop, mpz_t base, mpz_t exp, mpz_t mod);
 
+  /**
+   * 
+   * Compute the inverse of op1 modulo op2 and put the result in rop. If the inverse exists, the return 
+   * value is non-zero and rop will satisfy 0 <= rop < abs(op2) (with rop = 0 possible only when 
+   * abs(op2) = 1, i.e., in the somewhat degenerate zero ring). If an inverse doesn’t exist the return 
+   * value is zero and rop is undefined. The behaviour of this function is undefined when op2 is zero.
+   */
+  public static native int  __gmpz_invert(mpz_t rop, mpz_t op1, mpz_t op2);
+  
   private LibGmp() {
   }
 }

--- a/jnagmp/src/main/java/com/squareup/jnagmp/LibGmp.java
+++ b/jnagmp/src/main/java/com/squareup/jnagmp/LibGmp.java
@@ -315,14 +315,14 @@ public final class LibGmp {
   public static native void __gmpz_powm_sec(mpz_t rop, mpz_t base, mpz_t exp, mpz_t mod);
 
   /**
-   * 
-   * Compute the inverse of op1 modulo op2 and put the result in rop. If the inverse exists, the return 
-   * value is non-zero and rop will satisfy 0 <= rop < abs(op2) (with rop = 0 possible only when 
-   * abs(op2) = 1, i.e., in the somewhat degenerate zero ring). If an inverse doesn’t exist the return 
-   * value is zero and rop is undefined. The behaviour of this function is undefined when op2 is zero.
+   * Compute the inverse of op1 modulo op2 and put the result in rop. If the inverse exists, the
+   * return value is non-zero and rop will satisfy 0 <= rop < abs(op2) (with rop = 0 possible only
+   * when abs(op2) = 1, i.e., in the somewhat degenerate zero ring). If an inverse doesn’t exist
+   * the return value is zero and rop is undefined. The behaviour of this function is undefined when
+   * op2 is zero.
    */
   public static native int  __gmpz_invert(mpz_t rop, mpz_t op1, mpz_t op2);
-  
+
   private LibGmp() {
   }
 }

--- a/jnagmp/src/test/java/com/squareup/jnagmp/GmpTest.java
+++ b/jnagmp/src/test/java/com/squareup/jnagmp/GmpTest.java
@@ -125,29 +125,30 @@ public class GmpTest {
     strategy = SECURE_GMP_INTS;
     testOddExamples();
   }
-  
+
   @Test
   public void testModInverse() {
-    assertEquals(BigInteger.valueOf(2), Gmp.modInverse(BigInteger.valueOf(3), BigInteger.valueOf(5)));
+    assertEquals(BigInteger.valueOf(2),
+        Gmp.modInverse(BigInteger.valueOf(3), BigInteger.valueOf(5)));
     Random rnd = new Random();
     BigInteger m = new BigInteger(1024, rnd).nextProbablePrime();
-    for (int i=0; i<100; i++){ 
+    for (int i = 0; i < 100; i++) {
       BigInteger x = new BigInteger(1023, rnd);
       assertEquals(x.modInverse(m), Gmp.modInverse(x, m));
     }
   }
-  
+
   @Test
   public void testModInverseArithmeticException() {
-    try{
+    try {
       Gmp.modInverse(BigInteger.ONE, BigInteger.valueOf(-1));
       fail("ArithmeticException expected.");
-    } catch(ArithmeticException e) {      
+    } catch (ArithmeticException e) {
     }
-    try{
+    try {
       Gmp.modInverse(BigInteger.valueOf(3), BigInteger.valueOf(9));
       fail("ArithmeticException expected.");
-    } catch(ArithmeticException e) {      
+    } catch (ArithmeticException e) {
     }
   }
 

--- a/jnagmp/src/test/java/com/squareup/jnagmp/GmpTest.java
+++ b/jnagmp/src/test/java/com/squareup/jnagmp/GmpTest.java
@@ -17,6 +17,7 @@ package com.squareup.jnagmp;
 
 import com.squareup.jnagmp.ModPowVectors.TestVector;
 import java.math.BigInteger;
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -123,6 +124,31 @@ public class GmpTest {
   @Test public void testExamplesSecureGmpInts() {
     strategy = SECURE_GMP_INTS;
     testOddExamples();
+  }
+  
+  @Test
+  public void testModInverse() {
+    assertEquals(BigInteger.valueOf(2), Gmp.modInverse(BigInteger.valueOf(3), BigInteger.valueOf(5)));
+    Random rnd = new Random();
+    BigInteger m = new BigInteger(1024, rnd).nextProbablePrime();
+    for (int i=0; i<100; i++){ 
+      BigInteger x = new BigInteger(1023, rnd);
+      assertEquals(x.modInverse(m), Gmp.modInverse(x, m));
+    }
+  }
+  
+  @Test
+  public void testModInverseArithmeticException() {
+    try{
+      Gmp.modInverse(BigInteger.ONE, BigInteger.valueOf(-1));
+      fail("ArithmeticException expected.");
+    } catch(ArithmeticException e) {      
+    }
+    try{
+      Gmp.modInverse(BigInteger.valueOf(3), BigInteger.valueOf(9));
+      fail("ArithmeticException expected.");
+    } catch(ArithmeticException e) {      
+    }
   }
 
   private void testOddExamples() {


### PR DESCRIPTION
We are using your library for implementing homomorphic encryption schemes. During benchmarking I realised that the 'modInverse' implementation of BigInteger is an order of magnitude slower than the GMP one. 
Therefore I extended your code to also offer access to the GMP implementation for computing a modular inverse.
I believe this modifications could be useful to others trying to improve the runtime of their Java crypto implementations.