### PR TITLE
Loosen bcprov-jdk15on version pinning

### DIFF
--- a/bc-rsa/pom.xml
+++ b/bc-rsa/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.50</version>
+      <version>[1.50,)</version>
     </dependency>
 
     <!-- TEST DEPENDENCIES -->


### PR DESCRIPTION
They are up to 1.56, with backward compatible APIs.