### PR TITLE
Fix for #13

### DIFF
--- a/jnagmp/src/main/java/com/squareup/jnagmp/Gmp.java
+++ b/jnagmp/src/main/java/com/squareup/jnagmp/Gmp.java
@@ -116,7 +116,8 @@ public final class Gmp {
       throw new IllegalArgumentException("base must be non-negative");
     }
     if (exponent.signum() < 0) {
-      throw new IllegalArgumentException("exponent must be non-negative");
+      base = Gmp.modInverse(base, modulus);
+      exponent = exponent.negate();
     }
     return INSTANCE.get().modPowInsecureImpl(base, exponent, modulus);
   }

--- a/jnagmp/src/test/java/com/squareup/jnagmp/GmpTest.java
+++ b/jnagmp/src/test/java/com/squareup/jnagmp/GmpTest.java
@@ -324,7 +324,7 @@ public class GmpTest {
     }
 
     try {
-      modPow(1, -1, 1);
+      modPow(0, -1, 3);
       fail("ArithmeticException expected");
     } catch (ArithmeticException expected) {
     }

--- a/jnagmp/src/test/java/com/squareup/jnagmp/GmpTest.java
+++ b/jnagmp/src/test/java/com/squareup/jnagmp/GmpTest.java
@@ -106,18 +106,21 @@ public class GmpTest {
     strategy = JAVA;
     testOddExamples();
     testEvenExamples();
+    testNegativeExponentExamples();
   }
 
   @Test public void testExamplesInsecure() {
     strategy = INSECURE;
     testOddExamples();
     testEvenExamples();
+    testNegativeExponentExamples();
   }
 
   @Test public void testExamplesInsecureGmpInts() {
     strategy = INSECURE_GMP_INTS;
     testOddExamples();
     testEvenExamples();
+    testNegativeExponentExamples();
   }
 
   @Test public void testExamplesSecure() {
@@ -307,6 +310,11 @@ public class GmpTest {
     assertEquals(0, modPow(2, 3, 8));
   }
 
+  private void testNegativeExponentExamples() {
+    assertEquals(3, modPow(2, -1, 5));
+    assertEquals(1, modPow(4, -3, 7));
+  }
+
   @Test public void testSignErrorsInsecure() {
     strategy = INSECURE;
     try {
@@ -317,8 +325,8 @@ public class GmpTest {
 
     try {
       modPow(1, -1, 1);
-      fail("IllegalArgumentException expected");
-    } catch (IllegalArgumentException expected) {
+      fail("ArithmeticException expected");
+    } catch (ArithmeticException expected) {
     }
   }
 


### PR DESCRIPTION
Allow negative exponents in calls for modPowInsecure, by taking the modInverse of the base and negating the exponent.
Yields the expected ArithmeticException when the value cannot be inverted.